### PR TITLE
Add check_attributes function to PrecipTable.ipynb

### DIFF
--- a/PrecipTable.ipynb
+++ b/PrecipTable.ipynb
@@ -240,6 +240,7 @@
    ],
    "source": [
     "gdf = gpd.GeoDataFrame.from_file(polygon_dir)\n",
+    "check_attributes(gdf)\n",
     "\n",
     "gdf.head(2)"
    ]

--- a/core/hydromet.py
+++ b/core/hydromet.py
@@ -53,6 +53,16 @@ plib = 'pathlib.Path'
 #---------------------------------------------------------------------------#
 
 
+def check_attributes(gdf: geoDF) -> None:
+    '''Checks the passed geodataframe to make sure that "Volume" and "Region"
+       are not attributes, else the intersect_temporal_areas function will 
+       fail. 
+    '''
+    assert 'Volume' and 'Region' not in list(gdf.columns), ('"Volume" and '
+        '"Region" cannot be columns in the vector polygon. Rename columns '
+        'and reload')
+
+
 def intersect_temporal_areas(geo_df: geoDF, datarepository_dir: plib, 
            Temporal_area_filename: str, alldata: bool=False) -> (dict, geoDF):
     '''Intersects the area of interest with the NOAA Atlas 14 volumes and 


### PR DESCRIPTION
Checks that "Volume" and "Region" are not attributes within the area of interest vector polygon. This prevents an error created by duplicate columns during the intersection performed in order to extract the NOAA Atlas 14 volume and region from the NOAA_Temporal_Areas_US.geojson.